### PR TITLE
Add the manager type as input in boost/repay/close

### DIFF
--- a/contracts/mcd/saver/MCDSaverProxyHelper.sol
+++ b/contracts/mcd/saver/MCDSaverProxyHelper.sol
@@ -9,6 +9,8 @@ import "../../interfaces/Vat.sol";
 /// @title Helper methods for MCDSaverProxy
 contract MCDSaverProxyHelper is DSMath {
 
+    enum ManagerType { MCD, BPROTOCOL }
+
     /// @notice Returns a normalized debt _amount based on the current rate
     /// @param _amount Amount of dai to be normalized
     /// @param _rate Current rate of the stability fee
@@ -111,5 +113,15 @@ contract MCDSaverProxyHelper is DSMath {
         DSProxy proxy = DSProxy(uint160(_manager.owns(_cdpId)));
 
         return proxy.owner();
+    }
+
+    /// @notice Based on the manager type returns the address
+    /// @param _managerType Type of vault manager to use
+    function getManagerAddr(ManagerType _managerType) public pure returns (address) {
+        if (_managerType == ManagerType.MCD) {
+            return 0x5ef30b9986345249bc32d8928B7ee64DE9435E39;
+        } else if (_managerType == ManagerType.BPROTOCOL) {
+            return 0x3f30c2381CD8B917Dd96EB2f1A4F96D91324BBed;
+        }
     }
 }

--- a/contracts/mcd/saver/MCDSaverTaker.sol
+++ b/contracts/mcd/saver/MCDSaverTaker.sol
@@ -8,7 +8,7 @@ import "../../interfaces/ILendingPool.sol";
 
 contract MCDSaverTaker is MCDSaverProxy, GasBurner {
 
-    address payable public constant MCD_SAVER_FLASH_LOAN = 0xD0eB57ff3eA4Def2b74dc29681fd529D1611880f;
+    address payable public constant MCD_SAVER_FLASH_LOAN = 0x0A464cF970E23FEF801e6d2C773A6b0e99229aAe;
     address public constant AAVE_POOL_CORE = 0x3dfd23A6c5E8BbcFc9581d2E864a68feb6a076d3;
 
     ILendingPool public constant lendingPool = ILendingPool(0x398eC7346DcD622eDc5ae82352F02bE94C62d119);

--- a/contracts/shifter/protocols/McdShifter.sol
+++ b/contracts/shifter/protocols/McdShifter.sol
@@ -9,6 +9,8 @@ contract McdShifter is MCDSaverProxy {
 
     using SafeERC20 for ERC20;
 
+    Manager manager = Manager(0x5ef30b9986345249bc32d8928B7ee64DE9435E39);
+
     address public constant OPEN_PROXY_ACTIONS = 0x6d0984E80a86f26c0dd564ca0CF74a8E9Da03305;
 
     function getLoanAmount(uint _cdpId, address _joinAddr) public view virtual returns(uint loanAmount) {
@@ -35,12 +37,12 @@ contract McdShifter is MCDSaverProxy {
         (uint maxColl, ) = getCdpInfo(manager, _cdpId, ilk);
 
         // repay dai debt cdp
-        paybackDebt(_cdpId, ilk, _loanAmount, owner);
+        paybackDebt(address(manager), _cdpId, ilk, _loanAmount, owner);
 
         maxColl = _collateral > maxColl ? maxColl : _collateral;
 
         // withdraw collateral from cdp
-        drawCollateral(_cdpId, _joinAddr, maxColl);
+        drawCollateral(address(manager), _cdpId, _joinAddr, maxColl);
 
         // send back to msg.sender
         if (isEthJoinAddr(_joinAddr)) {
@@ -69,9 +71,9 @@ contract McdShifter is MCDSaverProxy {
             openAndWithdraw(collAmount, _debtAmount, address(this), _joinAddr);
         } else {
             // add collateral
-            addCollateral(_cdpId, _joinAddr, collAmount);
+            addCollateral(address(manager), _cdpId, _joinAddr, collAmount);
             // draw debt
-            drawDai(_cdpId, manager.ilks(_cdpId), _debtAmount);
+            drawDai(address(manager), _cdpId, manager.ilks(_cdpId), _debtAmount);
         }
 
         // transfer to repay FL


### PR DESCRIPTION
Adds managerType input 0 - mcdManager, 1 - bProtocolManager to SaverProxy and close. The shifter is still using the hardcoded manager due to other complications, we'll change that later. The enum is entered instead of address to limit possible attack scope.